### PR TITLE
Use default_factory for Embedding metadata

### DIFF
--- a/src/celeste_embeddings/core/types.py
+++ b/src/celeste_embeddings/core/types.py
@@ -4,7 +4,7 @@ Core data types for agent communication.
 
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from .enums import EmbeddingsProvider
 
@@ -25,4 +25,4 @@ class Embedding(BaseModel):
     values: list[float]
     usage: Optional[AIUsage] = None
     provider: Optional[EmbeddingsProvider] = None
-    metadata: Dict[str, Any] = {}
+    metadata: Dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
## Summary
- avoid mutable default in Embedding metadata by using `Field(default_factory=dict)`
- confirm no other mutable defaults in core types module

## Testing
- `pre-commit run --files src/celeste_embeddings/core/types.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891f50dd50c832cb4f61bea3df5fbab