### PR TITLE
refactor: Extract provider mapping to dedicated module

### DIFF
--- a/src/celeste_embeddings/__init__.py
+++ b/src/celeste_embeddings/__init__.py
@@ -2,6 +2,7 @@
 Celeste Embedding Client - Multi-provider embedding client for Python.
 """
 
+from importlib import import_module
 from typing import Any
 
 from celeste_core import Provider
@@ -9,47 +10,21 @@ from celeste_core.base.embedder import BaseEmbedder
 from celeste_core.config.settings import settings
 
 from .core import Embedding
+from .mapping import PROVIDER_MAPPING
 
 __version__ = "0.1.0"
 
-SUPPORTED_PROVIDERS: set[Provider] = {
-    Provider.GOOGLE,
-    Provider.MISTRAL,
-}
-
 
 def create_embedder(provider: str | Provider, **kwargs: Any) -> BaseEmbedder:
-    # normalize to enum
     provider_enum = Provider(provider) if isinstance(provider, str) else provider
-
-    if provider_enum not in SUPPORTED_PROVIDERS:
-        supported = [p.value for p in SUPPORTED_PROVIDERS]
+    if provider_enum not in PROVIDER_MAPPING:
         raise ValueError(
-            f"Unsupported provider: {provider_enum.value}. Supported: {supported}"
+            f"Provider '{provider_enum.value}' is not wired for embeddings."
         )
-
-    # Validate environment for the chosen provider
     settings.validate_for_provider(provider_enum.value)
-
-    mapping = {
-        Provider.GOOGLE: (".providers.google", "GoogleEmbedder"),
-        Provider.MISTRAL: (".providers.mistral", "MistralEmbedder"),
-    }
-
-    if provider_enum not in mapping:
-        supported = [p.value for p in mapping.keys()]
-        raise ValueError(
-            f"Provider {provider_enum.value} not implemented. Supported: {supported}"
-        )
-
-    module_path, class_name = mapping[provider_enum]
-    module = __import__(f"celeste_embeddings{module_path}", fromlist=[class_name])
-    embedder_class = getattr(module, class_name)
-    return embedder_class(**kwargs)
+    module_path, class_name = PROVIDER_MAPPING[provider_enum]
+    module = import_module(f"celeste_embeddings{module_path}")
+    return getattr(module, class_name)(**kwargs)
 
 
-__all__ = [
-    "create_embedder",
-    "BaseEmbedder",
-    "Embedding",
-]
+__all__ = ["create_embedder", "BaseEmbedder", "Embedding"]

--- a/src/celeste_embeddings/mapping.py
+++ b/src/celeste_embeddings/mapping.py
@@ -1,0 +1,11 @@
+from celeste_core.enums.capability import Capability
+from celeste_core.enums.providers import Provider
+
+CAPABILITY: Capability = Capability.EMBEDDINGS
+
+PROVIDER_MAPPING: dict[Provider, tuple[str, str]] = {
+    Provider.GOOGLE: (".providers.google", "GoogleEmbedder"),
+    Provider.MISTRAL: (".providers.mistral", "MistralEmbedder"),
+}
+
+__all__ = ["CAPABILITY", "PROVIDER_MAPPING"]


### PR DESCRIPTION
## Summary
- Extracts provider mapping configuration into a separate `mapping.py` module for better code organization
- Simplifies embedder creation logic by using `importlib.import_module` instead of `__import__`
- Adds `CAPABILITY` constant to identify this package as an embeddings provider

## Changes
- **New file `mapping.py`**: Contains provider mapping and capability constant
- **Updated `__init__.py`**: Simplified provider validation and dynamic import logic
- **Improved error messages**: More descriptive error when provider is not configured for embeddings

## Test Plan
- [ ] Verify existing embedder creation still works for Google provider
- [ ] Verify existing embedder creation still works for Mistral provider
- [ ] Confirm error handling for unsupported providers
- [ ] Ensure imports and module loading work correctly