### PR TITLE
Refactor embedder initialization to use proper inheritance

### DIFF
--- a/src/celeste_embeddings/providers/google.py
+++ b/src/celeste_embeddings/providers/google.py
@@ -10,8 +10,8 @@ class GoogleEmbedder(BaseEmbedder):
     def __init__(
         self, model: str = "gemini-embedding-exp-03-07", **kwargs: Any
     ) -> None:
+        super().__init__(model=model, provider=Provider.GOOGLE, **kwargs)
         self.client = genai.Client(api_key=settings.google.api_key)
-        self.embedding_model = model
 
     async def generate_embeddings(
         self, texts: Union[str, List[str]], **kwargs: Any
@@ -24,7 +24,7 @@ class GoogleEmbedder(BaseEmbedder):
             texts = [texts]
 
         response = await self.client.aio.models.embed_content(
-            model=self.embedding_model, contents=texts
+            model=self.model, contents=texts
         )
 
         vectors: List[List[float]] = [
@@ -34,5 +34,5 @@ class GoogleEmbedder(BaseEmbedder):
         return AIResponse(
             content=vectors,
             provider=Provider.GOOGLE,
-            metadata={"model": self.embedding_model},
+            metadata={"model": self.model},
         )

--- a/src/celeste_embeddings/providers/mistral.py
+++ b/src/celeste_embeddings/providers/mistral.py
@@ -8,8 +8,8 @@ from mistralai import Mistral
 
 class MistralEmbedder(BaseEmbedder):
     def __init__(self, model: str = "mistral-embed", **kwargs: Any) -> None:
+        super().__init__(model=model, provider=Provider.MISTRAL, **kwargs)
         self.client = Mistral(api_key=settings.mistral.api_key)
-        self.model = model
 
     async def generate_embeddings(
         self, texts: Union[str, List[str]], **kwargs: Any


### PR DESCRIPTION
## Summary
- Call `super().__init__()` in GoogleEmbedder and MistralEmbedder classes
- Remove duplicate model property assignments that are now handled by the base class
- Standardize initialization pattern across all embedder classes for better inheritance

## Test plan
- [ ] Verify GoogleEmbedder still functions correctly with embedding generation
- [ ] Verify MistralEmbedder still functions correctly with embedding generation
- [ ] Confirm all existing tests pass
- [ ] Check that model metadata is properly set in responses

🤖 Generated with [Claude Code](https://claude.ai/code)